### PR TITLE
add v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,7 @@ Errors
 |-----------|-----------------------------|
 | 400       | Missing parameters          |
 | 403       | Invalid token or IP address |
+| 409       | Blocked by another session  |
 | 500       | Unknown error by receiver   |
 
 ### 4.3 Cancel

--- a/README.md
+++ b/README.md
@@ -61,8 +61,9 @@ At the start of the app, the following message will be sent to the multicast gro
 ```json5
 {
   "alias": "Nice Orange",
+  "version": "2.0", // protocol version (major.minor)
   "deviceModel": "Samsung", // nullable
-  "deviceType": "mobile", // mobile | desktop | web | headless | server
+  "deviceType": "mobile", // mobile | desktop | web | headless | server, nullable
   "fingerprint": "random string",
   "port": 53317,
   "protocol": "https", // http | https
@@ -81,11 +82,12 @@ First, an HTTP/TCP request is sent to the origin:
 ```json5
 {
   "alias": "Secret Banana",
+  "version": "2.0",
   "deviceModel": "Windows",
   "deviceType": "desktop",
   "fingerprint": "random string", // ignored in HTTPS mode
   "port": 53317,
-  "protocol": "https", // http | https
+  "protocol": "https"
 }
 ```
 
@@ -94,11 +96,12 @@ As fallback, members can also respond with a Multicast/UDP message.
 ```json5
 {
   "alias": "Secret Banana",
+  "version": "2.0",
   "deviceModel": "Windows",
   "deviceType": "desktop",
   "fingerprint": "random string",
   "port": 53317,
-  "protocol": "https", // http | https
+  "protocol": "https",
   "announce": false
 }
 ```
@@ -120,6 +123,7 @@ Request
 ```json5
 {
   "alias": "Secret Banana",
+  "version": "2.0", // protocol version (major.minor)
   "deviceModel": "Windows",
   "deviceType": "desktop",
   "fingerprint": "random string", // ignored in HTTPS mode
@@ -133,6 +137,7 @@ Response
 ```json5
 {
   "alias": "Nice Orange",
+  "version": "2.0",
   "deviceModel": "Samsung",
   "deviceType": "mobile",
   "fingerprint": "random string" // ignored in HTTPS mode
@@ -171,6 +176,7 @@ Request
       "fileName": "my image.png",
       "size": 324242, // bytes
       "fileType": "image/jpeg",
+      "sha256": "*sha256 hash*", // nullable
       "preview": "*preview data*" // nullable
     },
     "another file id": {
@@ -178,6 +184,7 @@ Request
       "fileName": "another image.jpg",
       "size": 1234,
       "fileType": "image/jpeg",
+      "sha256": "*sha256 hash*",
       "preview": "*preview data*"
     }
   }
@@ -202,7 +209,6 @@ Errors
 |-----------|----------------------------|
 | 400       | Invalid body               |
 | 403       | Rejected                   |
-| 409       | Blocked by another session |
 | 500       | Unknown error by receiver  |
  
 ### 4.2 Send File
@@ -286,7 +292,7 @@ Response
   "info": {
     "alias": "Nice Orange",
     "deviceModel": "Samsung", // nullable
-    "deviceType": "mobile", // mobile | desktop | web
+    "deviceType": "mobile", // mobile | desktop | web | headless | server, nullable
   },
   "sessionId": "mySessionId",
   "files": {
@@ -295,6 +301,7 @@ Response
       "fileName": "my image.png",
       "size": 324242, // bytes
       "fileType": "image/jpeg",
+      "sha256": "*sha256 hash*", // nullable
       "preview": "*preview data*" // nullable
     },
     "another file id": {
@@ -302,6 +309,7 @@ Response
       "fileName": "another image.jpg",
       "size": 1234,
       "fileType": "image/jpeg",
+      "sha256": "*sha256 hash*",
       "preview": "*preview data*"
     }
   }
@@ -345,8 +353,10 @@ Response
 ```json5
 {
   "alias": "Nice Orange",
+  "version": "2.0",
   "deviceModel": "Samsung", // nullable
-  "deviceType": "mobile" // mobile | desktop | web
+  "deviceType": "mobile", // mobile | desktop | web | headless | server, nullable
+  "fingerprint": "random string"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ At the start of the app, the following message will be sent to the multicast gro
   "deviceModel": "Samsung", // nullable
   "deviceType": "mobile", // mobile | desktop | web | headless | server
   "fingerprint": "random string",
+  "port": 53317,
+  "protocol": "https", // http | https
   "announce": true
 }
 ```
@@ -81,7 +83,9 @@ First, an HTTP/TCP request is sent to the origin:
   "alias": "Secret Banana",
   "deviceModel": "Windows",
   "deviceType": "desktop",
-  "fingerprint": "random string" // ignored in HTTPS mode
+  "fingerprint": "random string", // ignored in HTTPS mode
+  "port": 53317,
+  "protocol": "https", // http | https
 }
 ```
 
@@ -93,6 +97,8 @@ As fallback, members can also respond with a Multicast/UDP message.
   "deviceModel": "Windows",
   "deviceType": "desktop",
   "fingerprint": "random string",
+  "port": 53317,
+  "protocol": "https", // http | https
   "announce": false
 }
 ```
@@ -116,7 +122,9 @@ Request
   "alias": "Secret Banana",
   "deviceModel": "Windows",
   "deviceType": "desktop",
-  "fingerprint": "random string" // ignored in HTTPS mode
+  "fingerprint": "random string", // ignored in HTTPS mode
+  "port": 53317,
+  "protocol": "https" // http | https
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -152,13 +152,13 @@ The receiver setups the HTTP server.
 
 The sender (i.e. HTTP client) sends files to the HTTP server.
 
-### 4.1 Send Request (Metadata only)
+### 4.1 Preparation (Metadata only)
 
 Sends only the metadata to the receiver.
 
 The receiver will decide if this request gets accepted, partially accepted or rejected.
 
-`POST /api/localsend/v2/send-request`
+`POST /api/localsend/v2/prepare-upload`
 
 Request
 
@@ -218,11 +218,11 @@ Errors
 
 The file transfer.
 
-Use the `sessionId`, the `fileId` and its file-specific `token` from `/send-request`.
+Use the `sessionId`, the `fileId` and its file-specific `token` from `/prepare-upload`.
 
 This route can be called in parallel.
 
-`POST /api/localsend/v2/send?sessionId=mySessionId&fileId=someFileId&token=someFileToken`
+`POST /api/localsend/v2/upload?sessionId=mySessionId&fileId=someFileId&token=someFileToken`
 
 Request
 
@@ -281,7 +281,7 @@ http://<sender-ip>:<sender-port>
 
 Send to the sender a request to get a list of file metadata.
 
-`POST /api/localsend/v2/receive-request`
+`POST /api/localsend/v2/prepare-download`
 
 Request
 
@@ -330,7 +330,7 @@ Use the `sessionId`, the `fileId` from `/receive-request`.
 
 This route can be called in parallel.
 
-`GET /api/localsend/v2/receive?sessionId=mySessionId&fileId=someFileId`
+`GET /api/localsend/v2/download?sessionId=mySessionId&fileId=someFileId`
 
 Request
 

--- a/README.md
+++ b/README.md
@@ -166,9 +166,12 @@ Request
 {
   "info": {
     "alias": "Nice Orange",
+    "version": "2.0", // protocol version (major.minor)
     "deviceModel": "Samsung", // nullable
-    "deviceType": "mobile",
-    "fingerprint": "random string" // ignored in HTTPS mode
+    "deviceType": "mobile", // mobile | desktop | web | headless | server, nullable
+    "fingerprint": "random string", // ignored in HTTPS mode
+    "port": 53317,
+    "protocol": "https" // http | https
   },
   "files": {
     "some file id": {
@@ -291,8 +294,10 @@ Response
 {
   "info": {
     "alias": "Nice Orange",
+    "version": "2.0",
     "deviceModel": "Samsung", // nullable
     "deviceType": "mobile", // mobile | desktop | web | headless | server, nullable
+    "fingerprint": "random string" // ignored in HTTPS mode
   },
   "sessionId": "mySessionId",
   "files": {

--- a/README.md
+++ b/README.md
@@ -281,6 +281,10 @@ http://<sender-ip>:<sender-port>
 
 Send to the sender a request to get a list of file metadata.
 
+The downloader may add `?sessionId=mySessionId`. In this case, the request should be accepted if it is the same session.
+
+This is needed if the user refreshes the browser page.
+
 `POST /api/localsend/v2/prepare-download`
 
 Request

--- a/README.md
+++ b/README.md
@@ -162,14 +162,14 @@ Request
       "id": "some file id",
       "fileName": "my image.png",
       "size": 324242, // bytes
-      "fileType": "image",
+      "fileType": "image/jpeg",
       "preview": "*preview data*" // nullable
     },
     "another file id": {
       "id": "another file id",
       "fileName": "another image.jpg",
       "size": 1234,
-      "fileType": "image",
+      "fileType": "image/jpeg",
       "preview": "*preview data*"
     }
   }
@@ -286,14 +286,14 @@ Response
       "id": "some file id",
       "fileName": "my image.png",
       "size": 324242, // bytes
-      "fileType": "image", // image | video | pdf | text | other
+      "fileType": "image/jpeg",
       "preview": "*preview data*" // nullable
     },
     "another file id": {
       "id": "another file id",
       "fileName": "another image.jpg",
       "size": 1234,
-      "fileType": "image",
+      "fileType": "image/jpeg",
       "preview": "*preview data*"
     }
   }
@@ -355,28 +355,9 @@ There is no difference in the protocol between the different device types.
 | Value    | Description                               |
 |----------|-------------------------------------------|
 | mobile   | mobile device (Android, iOS, FireOS)      |
-| desktop  | desktop (Windows, MacOS, Linux)           |
+| desktop  | desktop (Windows, macOS, Linux)           |
 | web      | web browser (Firefox, Chrome)             |
 | headless | program without GUI running on a terminal |
 | server   | (self-hosted) cloud service running 24/7  |
 
 The implementation handle unknown values. The official implementation falls back to `desktop`.
-
-### 7.2 File Type
-
-Different file types may be handled differently by the client.
-
-Text messages in particular are shown directly in the UI without the need to download the file if a `preview` is given.
-
-But there is no difference in the protocol between the different file types.
-
-| Value | Description            |
-|-------|------------------------|
-| image | Image (e.g. JPEG, PNG) |
-| video | Video (e.g. MP4)       |
-| pdf   | PDF document           |
-| text  | Text (message)         |
-| apk   | APK                    |
-| other | Other                  |
-
-The implementation should fall back to `other` for unknown values.

--- a/v1.md
+++ b/v1.md
@@ -1,18 +1,15 @@
-# LocalSend Protocol v2
+# LocalSend Protocol v1
 
 ## Table of Contents
 
 - [1. Defaults](#1-defaults)
-- [2. Fingerprint](#2-fingerprint)
-- [3. Discovery](#3-discovery)
-    - [3.1 Multicast](#31-multicast-udp-default)
-    - [3.2 HTTP](#32-http-legacy-mode)
-- [4. File transfer](#4-file-transfer-http)
-    - [4.1 Send request](#41-send-request-metadata-only)
-    - [4.2 Send file](#42-send-file)
-    - [4.3 Cancel](#43-cancel)
-- [5. Additional API](#5-additional-api)
-  - [5.1 Info](#51-info)
+- [2. Discovery](#2-discovery)
+    - [2.1 Multicast](#21-multicast-udp-default)
+    - [2.2 HTTP](#22-http-legacy-mode)
+- [3. File transfer](#3-file-transfer-http)
+    - [3.1 Send request](#31-send-request-metadata-only)
+    - [3.2 Send file](#32-send-file)
+    - [3.3 Cancel](#33-cancel)
 
 ## 1. Defaults
 
@@ -29,17 +26,9 @@ The default multicast group is 224.0.0.0/24 because some Android devices reject 
 **HTTP (TCP)**
 - Port: 53317
 
-## 2. Fingerprint
+## 2. Discovery
 
-The fingerprint is used to avoid self-discovery and to remember devices.
-
-When encryption is on (HTTPS), then the fingerprint is the SHA-256 hash of the certificate.
-
-When encryption is off (HTTP), then the fingerprint is a random generated string.
-
-## 3. Discovery
-
-### 3.1 Multicast UDP (Default)
+### 2.1 Multicast UDP (Default)
 
 **Announcement**
 
@@ -51,7 +40,7 @@ At the start of the app, the following message will be sent to the multicast gro
   "deviceModel": "Samsung", // nullable
   "deviceType": "mobile", // mobile | desktop | web
   "fingerprint": "random string",
-  "announce": true
+  "announcement": true
 }
 ```
 
@@ -61,14 +50,14 @@ Other LocalSend members will notice this message and will reply with their respe
 
 First, an HTTP/TCP request is sent to the origin:
 
-`POST /api/localsend/v2/register`
+`POST /api/localsend/v1/register`
 
 ```json5
 {
   "alias": "Secret Banana",
   "deviceModel": "Windows",
   "deviceType": "desktop",
-  "fingerprint": "random string" // ignored in HTTPS mode
+  "fingerprint": "random string"
 }
 ```
 
@@ -80,53 +69,43 @@ As fallback, members can also respond with a Multicast/UDP message.
   "deviceModel": "Windows",
   "deviceType": "desktop",
   "fingerprint": "random string",
-  "announce": false
+  "announcement": false
 }
 ```
 
 The `fingerprint` is only used to avoid self-discovering.
 
-A response is only triggered when `announce` is `true`.
+A response is only triggered when `announcement` is `true`.
 
-### 3.2 HTTP (Legacy Mode)
+### 2.2 HTTP (Legacy Mode)
 
 This method should be used when multicast was unsuccessful.
 
 Devices are discovered by sending this request to all local IP addresses.
 
-`POST /api/localsend/v2/register`
-
-Request
-
-```json5
-{
-  "alias": "Secret Banana",
-  "deviceModel": "Windows",
-  "deviceType": "desktop",
-  "fingerprint": "random string" // ignored in HTTPS mode
-}
-```
+`GET /api/localsend/v1/info?fingerprint=abc`
 
 Response
 
 ```json5
 {
   "alias": "Nice Orange",
-  "deviceModel": "Samsung",
-  "deviceType": "mobile",
-  "fingerprint": "random string" // ignored in HTTPS mode
+  "deviceModel": "Samsung", // nullable
+  "deviceType": "mobile" // mobile | desktop | web
 }
 ```
 
-## 4. File transfer (HTTP)
+## 3. File transfer (HTTP)
 
-### 4.1 Send Request (Metadata only)
+### 3.1 Send Request (Metadata only)
 
 Sends only the metadata to the receiver.
 
 The receiver will decide if this request gets accepted, partially accepted or rejected.
 
-`POST /api/localsend/v2/send-request`
+Be aware that only one active session is allowed, i.e. the server will reject all requests when another session is ongoing.
+
+`POST /api/localsend/v1/send-request`
 
 Request
 
@@ -135,8 +114,7 @@ Request
   "info": {
     "alias": "Nice Orange",
     "deviceModel": "Samsung", // nullable
-    "deviceType": "mobile", // mobile | desktop | web
-    "fingerprint": "random string" // ignored in HTTPS mode
+    "deviceType": "mobile" // mobile | desktop | web
   },
   "files": {
     "some file id": {
@@ -161,23 +139,20 @@ Response
 
 ```json5
 {
-  "sessionId": "mySessionId",
-  "files": {
-    "someFileId": "someFileToken",
-    "someOtherFileId": "someOtherFileToken"
-  }
+  "some file id": "some token",
+  "another file id": "some other token"
 }
 ```
 
-### 4.2 Send File
+### 3.2 Send File
 
 The file transfer.
 
-Use the `sessionId`, the `fileId` and its file-specific `token` from `/send-request`.
+Use the `fileId` and its file-specific `token` from `/send-request`.
 
 This route can be called in parallel.
 
-`POST /api/localsend/v2/send?sessionId=mySessionId&fileId=someFileId&token=someFileToken`
+`POST /api/localsend/v1/send?fileId=some file id&token=some token`
 
 Request
 
@@ -191,36 +166,16 @@ Response
 No body
 ```
 
-### 4.3 Cancel
+### 3.3 Cancel
 
 This route will be called when the sender wants to cancel the session.
 
-Use the `sessionId` from `/send-request`.
+The server will use the IP address to determine if the request is legitimate.
 
-`POST /api/localsend/v2/cancel?sessionId=mySessionId`
+`POST /api/localsend/v1/cancel`
 
 Response
 
 ```text
 No body
-```
-
-## 5. Additional API
-
-### 5.1 Info
-
-This was an old route previously used for discovery. This has been replaced with `/register` which is a two-way discovery.
-
-Now this route should be only used for debugging purposes.
-
-`GET /api/localsend/v2/info`
-
-Response
-
-```json5
-{
-  "alias": "Nice Orange",
-  "deviceModel": "Samsung", // nullable
-  "deviceType": "mobile" // mobile | desktop | web
-}
 ```


### PR DESCRIPTION
- two-way-SSL
- fingerprint is hash of HTTPS/TLS certificate
- add `sessionId` to fix https://github.com/localsend/localsend/issues/257
- with `sessionId` the receiver can technically handle multiple requests simultaneously
